### PR TITLE
添加Docker镜像文件

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,53 @@
+FROM ubuntu:22.04
+
+ENV ANTENNA_HOME=/opt/Antenna
+ENV MYSQL_HOST=127.0.0.1
+ENV MYSQL_PORT=3389
+ENV MYSQL_USERNAME=root
+ENV MYSQL_PASSWORD=passwd
+ENV PLATFORM_DOMAIN=
+ENV PLATFORM_IP=127.0.0.1
+
+WORKDIR $ANTENNA_HOME
+
+RUN apt-get update -y
+
+RUN apt-get install -y python3 python3-dev libmysqld-dev npm git \
+    && git clone https://github.com/wuba/Antenna.git ${ANTENNA_HOME}
+
+RUN cd $ANTENNA_HOME/bin/ \
+    && echo "MYSQL_HOST = '$MYSQL_HOST'" >./database_config.py \
+    && echo "MYSQL_PORT =  $MYSQL_PORT" >>./database_config.py \
+    && echo "MYSQL_USERNAME = '$MYSQL_USERNAME'" >>./database_config.py \
+    && echo "MYSQL_PASSWORD = '$MYSQL_PASSWORD'" >>./database_config.py \
+    && echo "PLATFORM_DOMAIN = '$PLATFORM_DOMAIN'" >>./database_config.py \
+    && echo "PLATFORM_IP = '$PLATFORM_IP'" >>./database_config.py
+    
+RUN cd "$ANTENNA_HOME/templates/" \
+    && echo "http://$PLATFORM_DOMAIN" >./reqUrl.txt
+
+RUN cd "$ANTENNA_HOME" \
+    && python3 ./manage.py makemigrations \
+    && echo "make migrations success!" \
+    && python3 ./manage.py migrate
+
+RUN key=$(echo $RANDOM | md5sum | head -c 32) \
+    && mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD -e "INSERT INTO antenna.api_key (id, \`key\`, update_time, user_id) VALUES (1, '$key', '2022-08-09 20:12:29.151182', 1);"
+
+RUN mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (1, 'PLATFORM_DOMAIN', 0, '$PLATFORM_DOMAIN', '2022-01-13 14:20:33', '2022-01-13 14:20:34');" \
+    && mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (2, 'DNS_DOMAIN', 1, '$PLATFORM_DOMAIN', '2022-01-13 14:22:40', '2022-01-13 14:22:45');" \
+    && mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (4, 'NS1_DOMAIN', 1, 'ns1.$PLATFORM_DOMAIN', '2022-01-13 14:23:10', '2022-01-13 14:23:12');" \
+    && mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (5, 'NS2_DOMAIN', 1, 'ns2.$PLATFORM_DOMAIN', '2022-01-13 14:23:42', '2022-01-13 14:23:44');" \
+    && mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (6, 'SERVER_IP', 1, '$PLATFORM_IP', '2022-01-13 14:25:06', '2022-01-13 14:25:08');" \
+    && mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD antenna <"$project_path/bin/config.sql"
+
+RUN cd cd "$ANTENNA_HOME/templates/"\
+    && npm install -g pm2 \
+    && npm install -g yarn \
+    && yarn config set registry https://registry.npm.taobao.org \
+    && yarn config set ignore-engines true \
+    && yarn \
+    && yarn _prepare \
+    && yarn start
+
+CMD [ "nohup python3 ./manage.py runserver 0.0.0.0:80 --noreload" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,9 @@ RUN git clone https://github.com/wuba/Antenna.git ${ANTENNA_HOME}
 
 RUN cd ${ANTENNA_HOME} \
     && apt-get install -y python3-pip \
-    && pip3 install -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
+    && python3 -m pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --upgrade pip\
+    && pip3 install -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple \
+    && pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple cryptography
 
 RUN apt-get install -y mysql-client
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,6 @@ RUN apt-get install -y mysql-client
 
 COPY ./entrypoint.sh /opt/entrypoint.sh
 
-EXPOSE 80
+EXPOSE 80 8000 2345
 
 CMD [ "/bin/bash", "/opt/entrypoint.sh" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 ENV ANTENNA_HOME=/opt/Antenna
 ENV MYSQL_HOST=127.0.0.1
-ENV MYSQL_PORT=3389
+ENV MYSQL_PORT=3306
 ENV MYSQL_USERNAME=root
 ENV MYSQL_PASSWORD=passwd
 ENV PLATFORM_DOMAIN=
@@ -12,42 +12,18 @@ WORKDIR $ANTENNA_HOME
 
 RUN apt-get update -y
 
-RUN apt-get install -y python3 python3-dev libmysqld-dev npm git \
-    && git clone https://github.com/wuba/Antenna.git ${ANTENNA_HOME}
+RUN apt-get install -y python3 python3-dev libmysqld-dev npm git
 
-RUN cd $ANTENNA_HOME/bin/ \
-    && echo "MYSQL_HOST = '$MYSQL_HOST'" >./database_config.py \
-    && echo "MYSQL_PORT =  $MYSQL_PORT" >>./database_config.py \
-    && echo "MYSQL_USERNAME = '$MYSQL_USERNAME'" >>./database_config.py \
-    && echo "MYSQL_PASSWORD = '$MYSQL_PASSWORD'" >>./database_config.py \
-    && echo "PLATFORM_DOMAIN = '$PLATFORM_DOMAIN'" >>./database_config.py \
-    && echo "PLATFORM_IP = '$PLATFORM_IP'" >>./database_config.py
-    
-RUN cd "$ANTENNA_HOME/templates/" \
-    && echo "http://$PLATFORM_DOMAIN" >./reqUrl.txt
+RUN git clone https://github.com/wuba/Antenna.git ${ANTENNA_HOME}
 
-RUN cd "$ANTENNA_HOME" \
-    && python3 ./manage.py makemigrations \
-    && echo "make migrations success!" \
-    && python3 ./manage.py migrate
+RUN cd ${ANTENNA_HOME} \
+    && apt-get install -y python3-pip \
+    && pip3 install -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
 
-RUN key=$(echo $RANDOM | md5sum | head -c 32) \
-    && mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD -e "INSERT INTO antenna.api_key (id, \`key\`, update_time, user_id) VALUES (1, '$key', '2022-08-09 20:12:29.151182', 1);"
+RUN apt-get install -y mysql-client
 
-RUN mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (1, 'PLATFORM_DOMAIN', 0, '$PLATFORM_DOMAIN', '2022-01-13 14:20:33', '2022-01-13 14:20:34');" \
-    && mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (2, 'DNS_DOMAIN', 1, '$PLATFORM_DOMAIN', '2022-01-13 14:22:40', '2022-01-13 14:22:45');" \
-    && mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (4, 'NS1_DOMAIN', 1, 'ns1.$PLATFORM_DOMAIN', '2022-01-13 14:23:10', '2022-01-13 14:23:12');" \
-    && mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (5, 'NS2_DOMAIN', 1, 'ns2.$PLATFORM_DOMAIN', '2022-01-13 14:23:42', '2022-01-13 14:23:44');" \
-    && mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (6, 'SERVER_IP', 1, '$PLATFORM_IP', '2022-01-13 14:25:06', '2022-01-13 14:25:08');" \
-    && mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD antenna <"$project_path/bin/config.sql"
+COPY ./entrypoint.sh /opt/entrypoint.sh
 
-RUN cd cd "$ANTENNA_HOME/templates/"\
-    && npm install -g pm2 \
-    && npm install -g yarn \
-    && yarn config set registry https://registry.npm.taobao.org \
-    && yarn config set ignore-engines true \
-    && yarn \
-    && yarn _prepare \
-    && yarn start
+EXPOSE 80
 
-CMD [ "nohup python3 ./manage.py runserver 0.0.0.0:80 --noreload" ]
+CMD [ "/bin/bash", "/opt/entrypoint.sh" ]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,9 @@ services:
   antenna:
     image: jongsx/antenna
     ports:
-      - 8080:80
+      - 80:80
+      - 8000:8000
+      - 2345:2345
     depends_on:
       - mysql
     links:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,17 +1,25 @@
 version: '3'
 services:
-  unomi:
+  antenna:
     image: jongsx/antenna
     ports:
-      - 80:80
+      - 8080:80
     depends_on:
-      - db
+      - mysql
     links:
-      - db
-  db:
+      - mysql
+    environment:
+      - MYSQL_HOST=mysql
+  mysql:
     image: mysql
     restart: always
-    command: --character-set-server=utf8 --collation-server=utf8_unicode_ci
+    command: [
+      '--default-authentication-plugin=mysql_native_password',
+      '--character-set-server=utf8',
+      '--collation-server=utf8_unicode_ci'
+    ]
+    ports:
+      - 3306:3306
     environment:
       MYSQL_ROOT_PASSWORD: passwd
       MYSQL_DATABASE: antenna

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  unomi:
+    image: jongsx/antenna
+    ports:
+      - 80:80
+    depends_on:
+      - db
+    links:
+      - db
+  db:
+    image: mysql
+    restart: always
+    command: --character-set-server=utf8 --collation-server=utf8_unicode_ci
+    environment:
+      MYSQL_ROOT_PASSWORD: passwd
+      MYSQL_DATABASE: antenna

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,6 @@ services:
     image: mysql
     restart: always
     command: [
-      '--default-authentication-plugin=mysql_native_password',
       '--character-set-server=utf8',
       '--collation-server=utf8_unicode_ci'
     ]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,47 @@
+# Waiting for mysql startup
+sleep 20
+
+cd "${ANTENNA_HOME}/bin/"
+echo "MYSQL_HOST = '$MYSQL_HOST'" >./database_config.py
+echo "MYSQL_PORT =  $MYSQL_PORT" >>./database_config.py
+echo "MYSQL_USERNAME = '$MYSQL_USERNAME'" >>./database_config.py
+echo "MYSQL_PASSWORD = '$MYSQL_PASSWORD'" >>./database_config.py
+echo "PLATFORM_DOMAIN = '$PLATFORM_DOMAIN'" >>./database_config.py
+echo "PLATFORM_IP = '$PLATFORM_IP'" >>./database_config.py
+cd "${ANTENNA_HOME}/templates/"
+echo "http://$PLATFORM_DOMAIN" >./reqUrl.txt
+
+cd ${ANTENNA_HOME}
+python3 ./manage.py makemigrations
+echo "make migrations success!"
+python3 ./manage.py migrate
+echo "migrate success!"
+
+echo "######生成个人api_key######"
+KEY=$(echo $RANDOM | md5sum | head -c 32)
+
+mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p $MYSQL_PASSWORD -e "INSERT INTO antenna.api_key (id, \`key\`, update_time, user_id) VALUES (1, '$KEY', '2022-08-09 20:12:29.151182', 1);"
+
+echo '######导入初始数据######'
+mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p $MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (1, 'PLATFORM_DOMAIN', 0, '$PLATFORM_DOMAIN', '2022-01-13 14:20:33', '2022-01-13 14:20:34');"
+mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p $MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (2, 'DNS_DOMAIN', 1, '$PLATFORM_DOMAIN', '2022-01-13 14:22:40', '2022-01-13 14:22:45');"
+mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p $MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (4, 'NS1_DOMAIN', 1, 'ns1.$PLATFORM_DOMAIN', '2022-01-13 14:23:10', '2022-01-13 14:23:12');"
+mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p $MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (5, 'NS2_DOMAIN', 1, 'ns2.$PLATFORM_DOMAIN', '2022-01-13 14:23:42', '2022-01-13 14:23:44');"
+mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p $MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (6, 'SERVER_IP', 1, '$PLATFORM_IP', '2022-01-13 14:25:06', '2022-01-13 14:25:08');"
+mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p $MYSQL_PASSWORD antenna < "${ANTENNA_HOME}/bin/config.sql"
+
+echo '######启动前端######'
+cd "${ANTENNA_HOME}/templates/"
+npm install -g pm2
+npm install -g yarn
+yarn config set registry https://registry.npm.taobao.org
+yarn config set ignore-engines true
 yarn
 yarn _prepare
 yarn start
-cd /opt/antenna
-nohup python3 ./manage.py runserver 0.0.0.0:80 --noreload &
+echo '######前端成功启动######'
+
+echo '######启动后端######'
+cd "${ANTENNA_HOME}"
+nohup python3 ./manage.py runserver 0.0.0.0:80 --noreload
+echo '######后端成功启动######'

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,5 @@
+yarn
+yarn _prepare
+yarn start
+cd /opt/antenna
+nohup python3 ./manage.py runserver 0.0.0.0:80 --noreload &

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -43,5 +43,5 @@ echo '######前端成功启动######'
 
 echo '######启动后端######'
 cd "${ANTENNA_HOME}"
-nohup python3 ./manage.py runserver 0.0.0.0:80 --noreload
+python3 ./manage.py runserver 0.0.0.0:80
 echo '######后端成功启动######'

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -20,15 +20,15 @@ echo "migrate success!"
 echo "######生成个人api_key######"
 KEY=$(echo $RANDOM | md5sum | head -c 32)
 
-mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p $MYSQL_PASSWORD -e "INSERT INTO antenna.api_key (id, \`key\`, update_time, user_id) VALUES (1, '$KEY', '2022-08-09 20:12:29.151182', 1);"
+mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD -e "INSERT INTO antenna.api_key (id, \`key\`, update_time, user_id) VALUES (1, '$KEY', '2022-08-09 20:12:29.151182', 1);"
 
 echo '######导入初始数据######'
-mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p $MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (1, 'PLATFORM_DOMAIN', 0, '$PLATFORM_DOMAIN', '2022-01-13 14:20:33', '2022-01-13 14:20:34');"
-mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p $MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (2, 'DNS_DOMAIN', 1, '$PLATFORM_DOMAIN', '2022-01-13 14:22:40', '2022-01-13 14:22:45');"
-mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p $MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (4, 'NS1_DOMAIN', 1, 'ns1.$PLATFORM_DOMAIN', '2022-01-13 14:23:10', '2022-01-13 14:23:12');"
-mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p $MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (5, 'NS2_DOMAIN', 1, 'ns2.$PLATFORM_DOMAIN', '2022-01-13 14:23:42', '2022-01-13 14:23:44');"
-mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p $MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (6, 'SERVER_IP', 1, '$PLATFORM_IP', '2022-01-13 14:25:06', '2022-01-13 14:25:08');"
-mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p $MYSQL_PASSWORD antenna < "${ANTENNA_HOME}/bin/config.sql"
+mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (1, 'PLATFORM_DOMAIN', 0, '$PLATFORM_DOMAIN', '2022-01-13 14:20:33', '2022-01-13 14:20:34');"
+mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (2, 'DNS_DOMAIN', 1, '$PLATFORM_DOMAIN', '2022-01-13 14:22:40', '2022-01-13 14:22:45');"
+mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (4, 'NS1_DOMAIN', 1, 'ns1.$PLATFORM_DOMAIN', '2022-01-13 14:23:10', '2022-01-13 14:23:12');"
+mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (5, 'NS2_DOMAIN', 1, 'ns2.$PLATFORM_DOMAIN', '2022-01-13 14:23:42', '2022-01-13 14:23:44');"
+mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD -e "INSERT INTO antenna.config (id, name, type, value, create_time, update_time) VALUES (6, 'SERVER_IP', 1, '$PLATFORM_IP', '2022-01-13 14:25:06', '2022-01-13 14:25:08');"
+mysql -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USERNAME -p$MYSQL_PASSWORD antenna < "${ANTENNA_HOME}/bin/config.sql"
 
 echo '######启动前端######'
 cd "${ANTENNA_HOME}/templates/"


### PR DESCRIPTION
改动：

- 增加Dockerfile和docker-compose文件

使用Ubuntu22.04作为基础镜像，用户可根据自己需要通过Dockerfile进行构建，并修改docker-compose中antenna下的image属性值。

已知问题：

通过命令
```
nohup python3 ./manage.py runserver 0.0.0.0:80 --noreload
```

启动后端会报如下错误，我认为这个错误与docker镜像的构建无关，所以并未去解决，而是标注在这里。

```
docker-antenna-1  | int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
docker-antenna-1  | Process Process-1:
docker-antenna-1  | Traceback (most recent call last):
docker-antenna-1  |   File "/usr/lib/python3.10/encodings/idna.py", line 165, in encode
docker-antenna-1  |     raise UnicodeError("label empty or too long")
docker-antenna-1  | UnicodeError: label empty or too long
docker-antenna-1  | 
docker-antenna-1  | The above exception was the direct cause of the following exception:
docker-antenna-1  | 
docker-antenna-1  | Traceback (most recent call last):
docker-antenna-1  |   File "/usr/lib/python3.10/multiprocessing/process.py", line 315, in _bootstrap
docker-antenna-1  |     self.run()
docker-antenna-1  |   File "/usr/lib/python3.10/multiprocessing/process.py", line 108, in run
docker-antenna-1  |     self._target(*self._args, **self._kwargs)
docker-antenna-1  |   File "/opt/Antenna/modules/template/depend/listen/dnslog.py", line 137, in main
docker-antenna-1  |     resolver = ZoneResolver(zone, True)
docker-antenna-1  |   File "/opt/Antenna/modules/template/depend/listen/dnslog.py", line 84, in __init__
docker-antenna-1  |     for rr in RR.fromZone(zone)]
docker-antenna-1  |   File "/usr/local/lib/python3.10/dist-packages/dnslib/dns.py", line 828, in fromZone
docker-antenna-1  |     return list(ZoneParser(zone,origin=origin,ttl=ttl))
docker-antenna-1  |   File "/usr/local/lib/python3.10/dist-packages/dnslib/dns.py", line 1857, in parse
docker-antenna-1  |     yield self.parse_rr(rr)
docker-antenna-1  |   File "/usr/local/lib/python3.10/dist-packages/dnslib/dns.py", line 1833, in parse_rr
docker-antenna-1  |     label = self.parse_label(rr.pop(0))
docker-antenna-1  |   File "/usr/local/lib/python3.10/dist-packages/dnslib/dns.py", line 1823, in parse_label
docker-antenna-1  |     self.label = DNSLabel(label)
docker-antenna-1  |   File "/usr/local/lib/python3.10/dist-packages/dnslib/label.py", line 89, in __init__
docker-antenna-1  |     self.label = tuple(label.encode("idna").\
docker-antenna-1  | UnicodeError: encoding with 'idna' codec failed (UnicodeError: label empty or too long)
```
